### PR TITLE
FIX: Return static docblocks

### DIFF
--- a/src/AbstractMultiton.php
+++ b/src/AbstractMultiton.php
@@ -25,7 +25,7 @@ abstract class AbstractMultiton implements MultitonInterface
      * @param string       $key             The string key associated with the member.
      * @param boolean|null $isCaseSensitive True if the search should be case sensitive.
      *
-     * @return MultitonInterface                           The member associated with the given string key.
+     * @return static                           The member associated with the given string key.
      * @throws Exception\UndefinedMemberExceptionInterface If no associated member is found.
      */
     final public static function memberByKey($key, $isCaseSensitive = null)
@@ -41,7 +41,7 @@ abstract class AbstractMultiton implements MultitonInterface
      * @param MultitonInterface|null $default         The default value to return.
      * @param boolean|null           $isCaseSensitive True if the search should be case sensitive.
      *
-     * @return MultitonInterface The member associated with the given string key, or the default value.
+     * @return static The member associated with the given string key, or the default value.
      */
     final public static function memberByKeyWithDefault(
         $key,
@@ -63,7 +63,7 @@ abstract class AbstractMultiton implements MultitonInterface
      * @param string|null  $key             The string key associated with the member, or null.
      * @param boolean|null $isCaseSensitive True if the search should be case sensitive.
      *
-     * @return MultitonInterface|null                      The member associated with the given string key, or null if the supplied key is null.
+     * @return static|null                      The member associated with the given string key, or null if the supplied key is null.
      * @throws Exception\UndefinedMemberExceptionInterface If no associated member is found.
      */
     final public static function memberOrNullByKey(
@@ -81,7 +81,7 @@ abstract class AbstractMultiton implements MultitonInterface
      * @param mixed        $value           The value to match.
      * @param boolean|null $isCaseSensitive True if the search should be case sensitive.
      *
-     * @return MultitonInterface                           The first member for which $member->{$property}() === $value.
+     * @return static                           The first member for which $member->{$property}() === $value.
      * @throws Exception\UndefinedMemberExceptionInterface If no associated member is found.
      */
     final public static function memberBy(
@@ -115,7 +115,7 @@ abstract class AbstractMultiton implements MultitonInterface
      * @param MultitonInterface|null $default         The default value to return.
      * @param boolean|null           $isCaseSensitive True if the search should be case sensitive.
      *
-     * @return MultitonInterface|null The first member for which $member->{$property}() === $value, or the default value.
+     * @return static|null The first member for which $member->{$property}() === $value, or the default value.
      */
     final public static function memberByWithDefault(
         $property,
@@ -155,7 +155,7 @@ abstract class AbstractMultiton implements MultitonInterface
      * @param mixed        $value           The value to match, or null.
      * @param boolean|null $isCaseSensitive True if the search should be case sensitive.
      *
-     * @return MultitonInterface|null                      The first member for which $member->{$property}() === $value, or null if the supplied value is null.
+     * @return static|null                      The first member for which $member->{$property}() === $value, or null if the supplied value is null.
      * @throws Exception\UndefinedMemberExceptionInterface If no associated member is found.
      */
     final public static function memberOrNullBy(
@@ -189,7 +189,7 @@ abstract class AbstractMultiton implements MultitonInterface
      *
      * @param callable $predicate The predicate applies to the member to find a match.
      *
-     * @return MultitonInterface                           The first member for which $predicate($member) evaluates to boolean true.
+     * @return static                           The first member for which $predicate($member) evaluates to boolean true.
      * @throws Exception\UndefinedMemberExceptionInterface If no associated member is found.
      */
     final public static function memberByPredicate($predicate)
@@ -213,7 +213,7 @@ abstract class AbstractMultiton implements MultitonInterface
      * @param callable               $predicate The predicate applied to the member to find a match.
      * @param MultitonInterface|null $default   The default value to return.
      *
-     * @return MultitonInterface The first member for which $predicate($member) evaluates to boolean true, or the default value.
+     * @return static The first member for which $predicate($member) evaluates to boolean true, or the default value.
      */
     final public static function memberByPredicateWithDefault(
         $predicate,
@@ -231,7 +231,7 @@ abstract class AbstractMultiton implements MultitonInterface
     /**
      * Returns an array of all members in this multiton.
      *
-     * @return array<string,MultitonInterface> All members.
+     * @return array<string,static> All members.
      */
     final public static function members()
     {
@@ -252,7 +252,7 @@ abstract class AbstractMultiton implements MultitonInterface
      * @param mixed        $value           The value to match.
      * @param boolean|null $isCaseSensitive True if the search should be case sensitive.
      *
-     * @return array<string,MultitonInterface> All members for which $member->{$property}() === $value.
+     * @return array<string,static> All members for which $member->{$property}() === $value.
      */
     final public static function membersBy(
         $property,
@@ -287,7 +287,7 @@ abstract class AbstractMultiton implements MultitonInterface
      *
      * @param callable $predicate The predicate applied to the members to find matches.
      *
-     * @return array<string,MultitonInterface> All members for which $predicate($member) evaluates to boolean true.
+     * @return array<string,static> All members for which $predicate($member) evaluates to boolean true.
      */
     final public static function membersByPredicate($predicate)
     {
@@ -307,7 +307,7 @@ abstract class AbstractMultiton implements MultitonInterface
      * @param string $key       The string key associated with the member.
      * @param array  $arguments Ignored.
      *
-     * @return MultitonInterface                           The member associated with the given string key.
+     * @return static                           The member associated with the given string key.
      * @throws Exception\UndefinedMemberExceptionInterface If no associated member is found.
      */
     final public static function __callStatic($key, array $arguments)
@@ -382,7 +382,7 @@ abstract class AbstractMultiton implements MultitonInterface
      * @param mixed                $value     The value of the property used to search for the member.
      * @param NativeException|null $cause     The cause, if available.
      *
-     * @return UndefinedMemberExceptionInterface The newly created exception.
+     * @return Exception\UndefinedMemberExceptionInterface The newly created exception.
      */
     protected static function createUndefinedMemberException(
         $className,

--- a/src/AbstractValueMultiton.php
+++ b/src/AbstractValueMultiton.php
@@ -23,7 +23,7 @@ abstract class AbstractValueMultiton extends AbstractMultiton implements
      * @param scalar       $value           The value associated with the member.
      * @param boolean|null $isCaseSensitive True if the search should be case sensitive.
      *
-     * @return ValueMultitonInterface             The first member with the supplied value.
+     * @return static             The first member with the supplied value.
      * @throws Exception\UndefinedMemberException If no associated member is found.
      */
     final public static function memberByValue($value, $isCaseSensitive = null)
@@ -39,7 +39,7 @@ abstract class AbstractValueMultiton extends AbstractMultiton implements
      * @param ValueMultitonInterface|null $default         The default value to return.
      * @param boolean|null                $isCaseSensitive True if the search should be case sensitive.
      *
-     * @return ValueMultitonInterface The first member with the supplied value, or the default value.
+     * @return static The first member with the supplied value, or the default value.
      */
     final public static function memberByValueWithDefault(
         $value,
@@ -61,7 +61,7 @@ abstract class AbstractValueMultiton extends AbstractMultiton implements
      * @param scalar|null  $value           The value associated with the member, or null.
      * @param boolean|null $isCaseSensitive True if the search should be case sensitive.
      *
-     * @return ValueMultitonInterface|null        The first member with the supplied value, or null if the supplied value is null.
+     * @return static|null        The first member with the supplied value, or null if the supplied value is null.
      * @throws Exception\UndefinedMemberException If no associated member is found.
      */
     final public static function memberOrNullByValue(
@@ -77,7 +77,7 @@ abstract class AbstractValueMultiton extends AbstractMultiton implements
      * @param scalar       $value           The value associated with the members.
      * @param boolean|null $isCaseSensitive True if the search should be case sensitive.
      *
-     * @return array<string,ValueMultitonInterface> All members with the supplied value.
+     * @return array<string,static> All members with the supplied value.
      */
     final public static function membersByValue($value, $isCaseSensitive = null)
     {


### PR DESCRIPTION
This fixes static analysis in editors such as PhpStorm. This enables calls such as `MyEnum::memberByValue($foo)` to return `MyEnum` instead of `ValueMultitonInterface` during static analysis thus avoiding warnings that `ValueMultitonInterface` does not match the expected type `MyEnum` when `MyEnum` is used as a type hint for method calls.