### PR TITLE
Added support for non-public enumeration constants

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ after_script: scripts/travis-after
 env:
     global:
         - ELOQUENT_PUBLISH_VERSION=7.1
-        - secure: "kK6XSHAaOLavtUZthJr3+VpsCedSrf0eJXz+lit/i2weg8g7RrReo2Ta/pWhzS3aP6mHkRKyB4UzMVebuFOoHuJkn+WGgnVUp1YhmL9F9wK4rzJQlGDmcwpSI3v6G69Mzm10o1v4ZVtAlaDD7MzbkTC8bw/Vg2BYeRZ8jFCzI7U="
 
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,9 @@ language: php
 
 matrix:
     include:
-        - php: 5.3
-          dist: precise
-        - php: 5.4
-        - php: 5.5
-        - php: 5.6
-        - php: 7.0
         - php: 7.1
         - php: 7.2
+        - php: 7.3
         - php: nightly
     fast_finish: true
     allow_failures:
@@ -17,8 +12,7 @@ matrix:
 
 before_install:
     - phpenv config-rm xdebug.ini || true
-    - composer config --global github-oauth.github.com $GITHUB_TOKEN
-install: composer install --prefer-dist --no-progress --no-interaction
+install: composer install --no-progress --no-interaction
 script: scripts/travis
 after_script: scripts/travis-after
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3"
+        "php": ">=7.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^4"
@@ -24,10 +24,5 @@
     },
     "autoload-dev": {
         "classmap": ["test/src"]
-    },
-    "config": {
-        "platform": {
-            "php": "5.3.99"
-        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,10 @@
     },
     "autoload-dev": {
         "classmap": ["test/src"]
+    },
+    "config": {
+        "platform": {
+            "php": "7.1.99"
+        }
     }
 }

--- a/src/AbstractEnumeration.php
+++ b/src/AbstractEnumeration.php
@@ -24,7 +24,33 @@ abstract class AbstractEnumeration extends AbstractValueMultiton implements
         $reflector = new ReflectionClass(get_called_class());
 
         foreach ($reflector->getConstants() as $key => $value) {
-            new static($key, $value);
+            if (self::isPublicConstant($reflector, $key)) {
+                new static($key, $value);
+            }
         }
+    }
+
+    /**
+     * Gets a value indicating whether the specified constant name is publicly accessible, according to the specified
+     * class reflector.
+     *
+     * This feature is not supported by all versions of PHP, so a check is performed to see if accessibility detection
+     * is available. This result of this check is statically cached so the check only occurs once per script lifetime.
+     *
+     * @param ReflectionClass $reflector Class reflector.
+     * @param string $name Constant name.
+     *
+     * @return bool True if the constant is public, otherwise false.
+     */
+    private static function isPublicConstant(ReflectionClass $reflector, $name)
+    {
+        static $methodExists;
+        $methodExists === null && $methodExists = method_exists($reflector, 'getReflectionConstants');
+
+        if (!$methodExists) {
+            return true;
+        }
+
+        return $reflector->getReflectionConstant($name)->isPublic();
     }
 }

--- a/src/AbstractEnumeration.php
+++ b/src/AbstractEnumeration.php
@@ -23,9 +23,9 @@ abstract class AbstractEnumeration extends AbstractValueMultiton implements
     {
         $reflector = new ReflectionClass(get_called_class());
 
-        foreach ($reflector->getConstants() as $key => $value) {
-            if ($reflector->getReflectionConstant($key)->isPublic()) {
-                new static($key, $value);
+        foreach ($reflector->getReflectionConstants() as $constant) {
+            if ($constant->isPublic()) {
+                new static($constant->getName(), $constant->getValue());
             }
         }
     }

--- a/src/AbstractEnumeration.php
+++ b/src/AbstractEnumeration.php
@@ -24,33 +24,9 @@ abstract class AbstractEnumeration extends AbstractValueMultiton implements
         $reflector = new ReflectionClass(get_called_class());
 
         foreach ($reflector->getConstants() as $key => $value) {
-            if (self::isPublicConstant($reflector, $key)) {
+            if ($reflector->getReflectionConstant($key)->isPublic()) {
                 new static($key, $value);
             }
         }
-    }
-
-    /**
-     * Gets a value indicating whether the specified constant name is publicly accessible, according to the specified
-     * class reflector.
-     *
-     * This feature is not supported by all versions of PHP, so a check is performed to see if accessibility detection
-     * is available. This result of this check is statically cached so the check only occurs once per script lifetime.
-     *
-     * @param ReflectionClass $reflector Class reflector.
-     * @param string $name Constant name.
-     *
-     * @return bool True if the constant is public, otherwise false.
-     */
-    private static function isPublicConstant(ReflectionClass $reflector, $name)
-    {
-        static $methodExists;
-        $methodExists === null && $methodExists = method_exists($reflector, 'getReflectionConstants');
-
-        if (!$methodExists) {
-            return true;
-        }
-
-        return $reflector->getReflectionConstant($name)->isPublic();
     }
 }

--- a/test/src/MixedAccessibilityEnumeration.php
+++ b/test/src/MixedAccessibilityEnumeration.php
@@ -1,0 +1,17 @@
+<?php
+
+use Eloquent\Enumeration\AbstractEnumeration;
+
+/**
+ * An enumeration whose members have different accessibility levels.
+ *
+ * @method static IMPLICIT_PUBLIC()
+ * @method static EXPLICIT_PUBLIC()
+ */
+final class MixedAccessibilityEnumeration extends AbstractEnumeration
+{
+    const IMPLICIT_PUBLIC = 'IMPLICIT_PUBLIC';
+    public const EXPLICIT_PUBLIC = 'EXPLICIT_PUBLIC';
+    protected const PROTECTED = 'PROTECTED';
+    private const PRIVATE = 'PRIVATE';
+}

--- a/test/suite/FunctionalTest.php
+++ b/test/suite/FunctionalTest.php
@@ -120,4 +120,18 @@ class FunctionalTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame($expected, $actual);
     }
+
+    /**
+     * Tests that only public constants are included as enumeration members.
+     *
+     * @requires PHP 7.1
+     */
+    public function testMixedAccessibility()
+    {
+        $members = MixedAccessibilityEnumeration::members();
+
+        self::assertCount(2, $members);
+        self::assertArrayHasKey(MixedAccessibilityEnumeration::IMPLICIT_PUBLIC, $members);
+        self::assertArrayHasKey(MixedAccessibilityEnumeration::EXPLICIT_PUBLIC, $members);
+    }
 }

--- a/test/suite/FunctionalTest.php
+++ b/test/suite/FunctionalTest.php
@@ -123,8 +123,6 @@ class FunctionalTest extends PHPUnit_Framework_TestCase
 
     /**
      * Tests that only public constants are included as enumeration members.
-     *
-     * @requires PHP 7.1
      */
     public function testMixedAccessibility()
     {


### PR DESCRIPTION
Previously, non-public constants were being included in enumerations.
However, non-public constants cannot be accessed externally so they
should not be part of the enumeration. This patch adds only public
constants, whether declared explicitly or implicitly, to the
enumeration.